### PR TITLE
do-release-upgrade -d and -p doesn't work

### DIFF
--- a/upgrade_testing/data/upgrade
+++ b/upgrade_testing/data/upgrade
@@ -310,7 +310,7 @@ function do_normal_upgrade() {
     # Allow upgrade from lts to non-lts if there's not lts to upgrade to
     local version
     if grep '^Prompt=lts' /etc/update-manager/release-upgrades; then
-        version=$(do-release-upgrade -d -p -c | awk '/New release/ {print $3}' | tr -d \')
+        version=$(do-release-upgrade -d -c | awk '/New release/ {print $3}' | tr -d \')
         if [ -z "${version}" ]; then
             # No LTS release to upgrade to. Enable non-LTS upgrades.
             sed -i 's/Prompt=lts/Prompt=normal/' /etc/update-manager/release-upgrades


### PR DESCRIPTION
(jammy-amd64)root@impulse:/home/bdmurray/source-trees/error-tracker-deployment/trunk# do-release-upgrade -d -p -c
The options --devel-release and --proposed are
mutually exclusive. Please use only one of them.

Dropping the -p should resolve upgrade issues from Jammy to Kinetic. I don't know why it just started failing though...