### PR TITLE
Small qemu command-line updates

### DIFF
--- a/upgrade_testing/command_line.py
+++ b/upgrade_testing/command_line.py
@@ -207,19 +207,11 @@ def get_adt_run_command(
     ] + adt_args.split()
 
     # Copy across the test scripts.
-    pre_dest_dir = "{testbed_location}/pre_scripts/".format(
+    scripts_dest_dir = "{testbed_location}/scripts/".format(
         testbed_location=get_testbed_storage_location()
     )
     copy_cmd = "--copy={src}:{dest}".format(
-        src=testrun_files.pre_scripts, dest=pre_dest_dir
-    )
-    adt_cmd.append(copy_cmd)
-
-    post_dest_dir = "{testbed_location}/post_scripts/".format(
-        testbed_location=get_testbed_storage_location()
-    )
-    copy_cmd = "--copy={src}:{dest}".format(
-        src=testrun_files.post_scripts, dest=post_dest_dir
+        src=testrun_files.scripts, dest=scripts_dest_dir
     )
     adt_cmd.append(copy_cmd)
 

--- a/upgrade_testing/configspec/_config.py
+++ b/upgrade_testing/configspec/_config.py
@@ -66,6 +66,8 @@ class TestSpecification:
             )
         )
 
+        self.scripts_data = details.get("scripts_data", None)
+
         backend_args = details.get("backend_args", [])
         self.backend_args = [
             arg.format(scripts_location=self.scripts_location)

--- a/upgrade_testing/configspec/_config.py
+++ b/upgrade_testing/configspec/_config.py
@@ -51,24 +51,24 @@ class TestSpecification:
     def _reader(self, details):
         self.name = details["testname"]
 
-        script_location = _get_script_location_path(
+        self.scripts_location = _get_script_location_path(
             details, self.provisioning._provisionconfig_path
         )
 
         self.pre_upgrade_scripts = ScriptStore(
             *_generate_script_list(
-                details["pre_upgrade_scripts"], script_location
+                details["pre_upgrade_scripts"], self.scripts_location
             )
         )
         self.post_upgrade_tests = ScriptStore(
             *_generate_script_list(
-                details["post_upgrade_tests"], script_location
+                details["post_upgrade_tests"], self.scripts_location
             )
         )
 
         backend_args = details.get("backend_args", [])
         self.backend_args = [
-            arg.format(script_location=script_location) for arg in backend_args
+            arg.format(script_location=self.scripts_location) for arg in backend_args
         ]
 
     @property

--- a/upgrade_testing/configspec/_config.py
+++ b/upgrade_testing/configspec/_config.py
@@ -68,7 +68,8 @@ class TestSpecification:
 
         backend_args = details.get("backend_args", [])
         self.backend_args = [
-            arg.format(script_location=self.scripts_location) for arg in backend_args
+            arg.format(scripts_location=self.scripts_location)
+            for arg in backend_args
         ]
 
     @property
@@ -90,7 +91,7 @@ def _get_script_location_path(provision_details, provisionfile_path):
     """Return the full path for a script location."""
     # If script_location starts with ./ or ../ then we need to get the abs path
     # of the provision file and append it.
-    location = provision_details.get("script_location", None)
+    location = provision_details.get("scripts_location", None)
     if location is None:
         return location
     if location.startswith("file://."):

--- a/upgrade_testing/data/upgrade
+++ b/upgrade_testing/data/upgrade
@@ -2,8 +2,7 @@
 
 TMP_LOCATION="/var/tmp/ubuntu-upgrade-testing"
 BASE_LOCATION="${ADT_ARTIFACTS}/upgrade_run_config"
-PRE_SCRIPT_LOCATION="${BASE_LOCATION}/pre_scripts"
-POST_SCRIPT_LOCATION="${BASE_LOCATION}/post_scripts"
+SCRIPTS_LOCATION="${BASE_LOCATION}/scripts"
 # Currently experimenting with using yaml output for run results (test
 # pass/fail etc.) for now, then we'll use something better
 TEST_RESULTS_DIR="${ADT_ARTIFACTS}/upgrade_run"
@@ -13,8 +12,7 @@ CANARY_NAME="/tmp/upgrade_script_reboot_canary"
 # Only copy on the first run through
 if [ ! -d "${BASE_LOCATION}" ]; then
    mkdir "${BASE_LOCATION}"
-   mv "${TMP_LOCATION}/pre_scripts" "${BASE_LOCATION}"
-   mv "${TMP_LOCATION}/post_scripts" "${BASE_LOCATION}"
+   mv "${TMP_LOCATION}/scripts" "${BASE_LOCATION}"
    mv "${TMP_LOCATION}/auto_upgrade_test_settings" "${BASE_LOCATION}"
 fi
 
@@ -166,7 +164,7 @@ function pre_tests() {
         mkdir "${this_script_results}"
         export TESTRUN_RESULTS_DIR=$this_script_results
 
-        local FULL_TEST_SCRIPT_PATH="${PRE_SCRIPT_LOCATION}/${test}"
+        local FULL_TEST_SCRIPT_PATH="${SCRIPTS_LOCATION}/${test}"
         upgrade_log "Running test: ${FULL_TEST_SCRIPT_PATH} -- Results: ${this_script_results}"
         ${FULL_TEST_SCRIPT_PATH}
 
@@ -193,7 +191,7 @@ function post_tests() {
         mkdir "${this_script_results}"
         export TESTRUN_RESULTS_DIR=$this_script_results
 
-        local FULL_TEST_SCRIPT_PATH="${POST_SCRIPT_LOCATION}/${test}"
+        local FULL_TEST_SCRIPT_PATH="${SCRIPTS_LOCATION}/${test}"
         upgrade_log "Running test: ${FULL_TEST_SCRIPT_PATH} -- Results: ${this_script_results}"
 
         ${FULL_TEST_SCRIPT_PATH}

--- a/upgrade_testing/preparation/_hostprep.py
+++ b/upgrade_testing/preparation/_hostprep.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import json
 import logging
 import os
 import shutil
@@ -74,6 +75,11 @@ def prepare_test_environment(testsuite):
 
         scripts_path = os.path.join(temp_dir, "scripts")
         _copy_script_files(testsuite.scripts_location, scripts_path)
+
+        if hasattr(testsuite, "scripts_data"):
+            data_path = os.path.join(temp_dir, "scripts_data.json")
+            with open(data_path, "w") as f:
+                json.dump(testsuite.scripts_data, f)
 
         adt_base_path, adt_cmd = _get_adt_path(temp_dir)
 

--- a/upgrade_testing/preparation/_hostprep.py
+++ b/upgrade_testing/preparation/_hostprep.py
@@ -47,8 +47,7 @@ TestrunTempFiles = namedtuple(
         "run_config_file",
         "testrun_tmp_dir",
         "unbuilt_dir",
-        "pre_scripts",
-        "post_scripts",
+        "scripts",
     ],
 )
 
@@ -73,11 +72,8 @@ def prepare_test_environment(testsuite):
         unbuilt_dir = _create_autopkg_details(temp_dir)
         logger.info("Unbuilt dir: {}".format(unbuilt_dir))
 
-        pre_path = os.path.join(temp_dir, "pre_scripts")
-        _copy_script_files(testsuite.pre_upgrade_scripts.location, pre_path)
-
-        post_path = os.path.join(temp_dir, "post_scripts")
-        _copy_script_files(testsuite.post_upgrade_tests.location, post_path)
+        scripts_path = os.path.join(temp_dir, "scripts")
+        _copy_script_files(testsuite.scripts_location, scripts_path)
 
         adt_base_path, adt_cmd = _get_adt_path(temp_dir)
 
@@ -88,8 +84,7 @@ def prepare_test_environment(testsuite):
             # Should we create a dir so that it won't interfer?
             unbuilt_dir=temp_dir,
             testrun_tmp_dir=temp_dir,
-            pre_scripts=pre_path,
-            post_scripts=post_path,
+            scripts=scripts_path,
         )
     finally:
         _cleanup_dir(temp_dir)
@@ -115,8 +110,8 @@ def _write_run_config(testsuite, temp_dir):
         config_string = dedent(
             """\
             # Auto Upgrade Test Configuration
-            PRE_TEST_LOCATION="{testbed_location}/pre_scripts"
-            POST_TEST_LOCATION="{testbed_location}/post_scripts"
+            PRE_TEST_LOCATION="{testbed_location}/scripts"
+            POST_TEST_LOCATION="{testbed_location}/scripts"
         """.format(
                 testbed_location=get_testbed_storage_location()
             )

--- a/upgrade_testing/provisioning/backends/_qemu.py
+++ b/upgrade_testing/provisioning/backends/_qemu.py
@@ -174,6 +174,8 @@ class QemuBackend(SshBackend):
                 "qcow2",
                 "-b",
                 os.path.join(CACHE_DIR, self.image_name),
+                "-F",
+                "qcow2",
                 overlay_img,
             ]
         )

--- a/upgrade_testing/provisioning/backends/_qemu.py
+++ b/upgrade_testing/provisioning/backends/_qemu.py
@@ -33,7 +33,7 @@ from upgrade_testing.provisioning.backends._ssh import SshBackend
 CACHE_DIR = "/var/cache/auto-upgrade-testing"
 OVERLAY_DIR = os.path.join(CACHE_DIR, "overlay")
 QEMU_LAUNCH_OPTS = (
-    "{qemu} -m {ram} -smp {cpu} -pidfile {workdir}/qemu.pid -localtime "
+    "{qemu} -m {ram} -smp {cpu} -pidfile {workdir}/qemu.pid -rtc base=localtime "
     "-cpu core2duo -enable-kvm "
 )
 QEMU_SYSTEM_AMD64 = "qemu-system-x86_64"


### PR DESCRIPTION
With more recent versions of qemu, these old QEMU CLI flags have stopped working. Both those changes are for example needed for development using the `--keep-overlay` flag on `noble`.