### PR TITLE
Bump DEFAULT_RAM from 2GB to 3GB

### DIFF
--- a/upgrade_testing/provisioning/backends/_qemu.py
+++ b/upgrade_testing/provisioning/backends/_qemu.py
@@ -50,7 +50,7 @@ QEMU_DISK_IMAGE_OPTS = "-drive file={disk_img},if=virtio "
 QEMU_DISK_IMAGE_OVERLAY_OPTS = (
     "-drive file={overlay_img},cache=unsafe,if=virtio,index=0 "
 )
-DEFAULT_RAM = "2048"
+DEFAULT_RAM = "3072"
 DEFAULT_CPU = "2"
 TIMEOUT_REBOOT = "300"
 HEADLESS = True


### PR DESCRIPTION
The recommended minimum requirement is 4GB [1], so we should be still on the safe side with 3GB.

[1] https://help.ubuntu.com/community/Installation/SystemRequirements