### PR TITLE
Make sure '/tmp' is a tmpfs that gets cleaned

### DIFF
--- a/upgrade_testing/data/upgrade
+++ b/upgrade_testing/data/upgrade
@@ -230,6 +230,9 @@ function do_setup() {
     # Make sure the output results file is available and proper yaml.
     mkdir "${TEST_RESULTS_DIR}"
     echo "---" >> "${TEST_RESULT_FILE}"
+
+    upgrade_log "Make sure /tmp is a tmpfs."
+    rm -f "/etc/systemd/system/tmp.mount"
 }
 
 function need_another_upgrade() {


### PR DESCRIPTION
With `systemd` v256 and LP: #2019026, `/tmp` was made a `tmpfs` by default. This led to LP: #2069834, and `autopkgtest` now has a mechanism to prevent `/tmp` to be a tmpfs. Probably due to a bug that still requires investigation, `/tmp` is not cleaned upon reboot, making our canary to stay, and the upgrade to fail inappropriately. This patch removes the `autopkgtest` created file that prevents `/tmp` to be a `tmpfs`, making the upgrade green again.

As mentionned, `tmpfs` or not, `/tmp` should be cleaned, meaning further investigation is needed there to get to the bottom of it.