### PR TITLE
Cleaner base image generation

### DIFF
--- a/upgrade_testing/command_line.py
+++ b/upgrade_testing/command_line.py
@@ -65,6 +65,18 @@ def parse_args():
         help="Provision the requested backend",
     )
     parser.add_argument(
+        "--verbose-provision",
+        "-v",
+        action="store_true",
+        help="Provision with with build output enabled.",
+    )
+    parser.add_argument(
+        "--force-provision",
+        "-f",
+        action="store_true",
+        help="Provision a new image regardless of cache.",
+    )
+    parser.add_argument(
         "--results-dir",
         help="Directory to store results generated during the run.",
     )
@@ -262,9 +274,13 @@ def main():
         # Note this could raise an exception.
 
         with prepare_test_environment(testsuite) as created_files:
-            if not testsuite.provisioning.backend_available():
+            if (
+                args.force_provision
+                or not testsuite.provisioning.backend_available()
+            ):
                 if args.provision:
                     logger.debug("Provising backend.")
+                    testsuite.provisioning.set_verbose(args.verbose_provision)
                     testsuite.provisioning.create(created_files.adt_base_path)
                 else:
                     logger.error(

--- a/upgrade_testing/provisioning/_provisionconfig.py
+++ b/upgrade_testing/provisioning/_provisionconfig.py
@@ -160,12 +160,14 @@ class QemuProvisionSpecification(ProvisionSpecification):
         )
         logger.info("Using build args: {}".format(self.build_args))
 
+        self.packages = provision_config.get("packages")
         self.verbose = False
 
         self.backend = backends.QemuBackend(
             self.initial_state,
             self.arch,
             self.image_name,
+            self.packages,
             self.build_args,
         )
 

--- a/upgrade_testing/provisioning/_provisionconfig.py
+++ b/upgrade_testing/provisioning/_provisionconfig.py
@@ -64,6 +64,9 @@ class ProvisionSpecification:
         """Return list with the adt args for this provisioning backend."""
         raise NotImplementedError()
 
+    def set_verbose(self, verbose):
+        self.backend.set_verbose(verbose)
+
     @staticmethod
     def from_testspec(spec, spec_path):
         backend_name = spec["provisioning"]["backend"]
@@ -156,6 +159,8 @@ class QemuProvisionSpecification(ProvisionSpecification):
             provision_config.get("build_args", []), provision_config_directory
         )
         logger.info("Using build args: {}".format(self.build_args))
+
+        self.verbose = False
 
         self.backend = backends.QemuBackend(
             self.initial_state,

--- a/upgrade_testing/provisioning/backends/_base.py
+++ b/upgrade_testing/provisioning/backends/_base.py
@@ -45,6 +45,9 @@ class ProviderBackend:
         """Return a list containing required args to pass to autopkgtest."""
         raise NotImplementedError()
 
+    def set_verbose(self, verbose):
+        self.verbose = verbose
+
     @property
     def name(self):
         raise NotImplementedError()

--- a/upgrade_testing/provisioning/backends/_qemu.py
+++ b/upgrade_testing/provisioning/backends/_qemu.py
@@ -88,15 +88,17 @@ class QemuBackend(SshBackend):
         """Create a qemu image."""
 
         logger.info("Creating qemu image for run.")
-        cmd = "{builder_cmd} -a {arch} -r {release} -o {output} {args}".format(
+        cmd = "{builder_cmd} -a {arch} -r {release} -o {output} {verbose} {args}".format(
             builder_cmd=os.path.join(
                 adt_base_path, "autopkgtest-buildvm-ubuntu-cloud"
             ),
             arch=self.arch,
             release=self.release,
             output=CACHE_DIR,
+            verbose="-v" if self.verbose else "",
             args=" ".join(self.build_args),
         )
+            
         run_command_with_logged_output(cmd, shell=True)
 
         initial_image_name = "autopkgtest-{}-{}.img".format(


### PR DESCRIPTION
Adds custom cloud-init based image generation. By not running the default buildvm-ubuntu-cloud cloud-init config we can keep the testbed from being stripped down (which makes for more realistic upgrade scenarios) as well as having an opportunity to install flavor metapackages before testing starts, compared to the current method of installing a flavor metapackage as part of testing. 

This change is meant to be in [tandem with a change to the testing specifications ](https://code.launchpad.net/~uralt/auto-upgrade-testing-specifications/+git/auto-upgrade-testing-specifications/+merge/480323) which will now include a "metapackages" list for all packages that should be installed during image generation.

To test the changes, one can run `command_line.py --config /path/to/auto-upgrade-testing-specifications/profiles/ubuntu-oracular-plucky-basic-amd64_qemu.yaml --provision --force-provision`. `--force-provision` ensures a cached image is not used. 