### PR TITLE
Add additonal packages required by testbeds

### DIFF
--- a/upgrade_testing/provisioning/backends/_qemu.py
+++ b/upgrade_testing/provisioning/backends/_qemu.py
@@ -181,7 +181,11 @@ package_upgrade: true
 packages:
  # linux-generic is necessary to get a graphical session
  - linux-generic
+ # packages required for testing
+ - apport-noui
+ - eatmydata
  - ubuntu-release-upgrader-core
+ # packages wanted by profile
 %(packages)s
 write_files:
  - content: |


### PR DESCRIPTION
All tests require apport-noui, also including eatmydata for good measure. Adding to testbed images instead of installing during testing.