### PR TITLE
Strip porcelain output from kernel upgrade check

### DIFF
--- a/upgrade_testing/data/upgrade
+++ b/upgrade_testing/data/upgrade
@@ -327,7 +327,8 @@ function do_normal_upgrade() {
     apt-get -y install openssh-server update-manager-core
 
     kernel=$(uname -r)
-    pre_upgrade_kernel_check=$(dpkg -l "linux-*-$kernel" | grep -v '^.n')
+    pre_upgrade_kernel_check=$(dpkg -l "linux-*-$kernel" | grep '^.i')
+    pre_upgrade_kernel_check_pretty=$(dpkg -l "linux-*-$kernel")
 
     # Allow upgrade from lts to non-lts if there's not lts to upgrade to
     local version
@@ -363,11 +364,12 @@ function do_normal_upgrade() {
         upgrade_log "Proposed version found: ${version}, using it"
         do-release-upgrade -p -f DistUpgradeViewNonInteractive
     fi
-    post_upgrade_kernel_check=$(dpkg -l "linux-*-$kernel" | grep -v '^.n')
+    post_upgrade_kernel_check=$(dpkg -l "linux-*-$kernel" | grep '^.i')
+    post_upgrade_kernel_check_pretty=$(dpkg -l "linux-*-$kernel")
     if [[ "${pre_upgrade_kernel_check}" != "${post_upgrade_kernel_check}" ]]; then
         upgrade_log "Different packages are installed for the kernel booted during upgrade!"
-        upgrade_log "Pre upgrade kernel was:\n${pre_upgrade_kernel_check}"
-        upgrade_log "Post upgrade kernel was:\n${post_upgrade_kernel_check}"
+        upgrade_log "Pre upgrade kernel was:\n${pre_upgrade_kernel_check_pretty}"
+        upgrade_log "Post upgrade kernel was:\n${post_upgrade_kernel_check_pretty}"
         STATUS=1
         return
     else


### PR DESCRIPTION
... and only use the dpkg list entries for the comparison. The pretty version still contains the "porcelain" (abbreviations and list headers) for printing nicer logs.